### PR TITLE
Adding 'composer update' for phpMyAdmin in ansible tasks

### DIFF
--- a/ansible/roles/phpmyadmin/tasks/main.yml
+++ b/ansible/roles/phpmyadmin/tasks/main.yml
@@ -12,6 +12,11 @@
     # echo "Copy parameters.yml and create database"
     # cp -f /vagrant/config/symfony/parameters.yml /var/www/symfony/app/config/parameters.yml
 
+- name: Finish install of phpmyadmin
+  composer:
+    command: update
+    working_dir: /var/www/phpmyadmin
+
 - name: Copy conf for apache
   template: src=phpmyadmin.tpl dest=/etc/httpd/conf.d/phpmyadmin.conf owner=root group=root mode=0644
 


### PR DESCRIPTION
Before this update when phpmyadmin wasn't totally installed, we had to launch `composer update` in `/var/www/phpmyadmin`.

I add the composer update to the phpMyAdmin ansibles's tasks. 